### PR TITLE
Fix: replace invalid jenkins user w/ $USER=deploy

### DIFF
--- a/cleaner.sh
+++ b/cleaner.sh
@@ -11,6 +11,7 @@ DEFAULT_JENKINS_DIR="/var/lib/jenkins"
 DEFAULT_JENKINS_DIR_COUNT=${#DEFAULT_JENKINS_DIR}
 WORKSPACE_DIR=$(pwd)
 WORKSPACE_DIR_COUNT=${#WORKSPACE_DIR}
+USER="deploy"
 
 # Make sure we are not executing rm -rf /
 if [ "$WORKSPACE_DIR_COUNT" -gt "$DEFAULT_JENKINS_DIR_COUNT" ]; then
@@ -18,8 +19,8 @@ echo "Executing folder removal and re-creation."
 sudo rm -rf $WORKSPACE_DIR/*
 sudo rm -rf $WORKSPACE_DIR/.g*
 echo "Removed folder: ${WORKSPACE_DIR}"
-sudo chown -R jenkins:jenkins $WORKSPACE_DIR
-echo "Ownership set as jenkins:jenkins : ${WORKSPACE_DIR}"
+sudo chown -R $USER:$USER $WORKSPACE_DIR
+echo "Ownership set as ${USER}:${USER} : ${WORKSPACE_DIR}"
 exit 0;
 fi
 


### PR DESCRIPTION
jenkins user does not exist on any of our server instances.
(maybe) resolves the following build error:

```
+ bash ./cleaner.sh
Who am I ?
deploy
Where am I ?
/home/deploy/workspace/mu-plugins_production
Executing folder removal and re-creation.
Removed folder: /home/deploy/workspace/mu-plugins_production
chown: invalid user: ‘jenkins:jenkins’
Ownership set as jenkins:jenkins : /home/deploy/workspace/mu-plugins_production
```